### PR TITLE
Bugfix for supervisor and useradd while fhem installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,47 +12,35 @@ RUN mkdir -p /var/log/supervisor
 COPY ./etc/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Install perl packages
-#RUN apt-get -y install libalgorithm-merge-perl \
-#libclass-isa-perl \
-#libcommon-sense-perl \
-#libdpkg-perl \
-#liberror-perl \
-#libfile-copy-recursive-perl \
-#libfile-fcntllock-perl \
-#libio-socket-ip-perl \
-#libio-socket-multicast-perl \
-#libjson-perl \
-#libjson-xs-perl \
-#libmail-sendmail-perl \
-#libsocket-perl \
-#libswitch-perl \
-#libsys-hostname-long-perl \
-#libterm-readkey-perl \
-#libterm-readline-perl-perl \
-#libxml-simple-perl \
-#libcrypt-pbkdf2-perl \
-#libcpan-meta-yaml-perl \
-#libxml-simple-perl \
-#build-essential
-#
-#RUN cpan install Net::MQTT:Simple
+RUN apt-get -y install libalgorithm-merge-perl \
+libclass-isa-perl \
+libcommon-sense-perl \
+libdpkg-perl \
+liberror-perl \
+libfile-copy-recursive-perl \
+libfile-fcntllock-perl \
+libio-socket-ip-perl \
+libio-socket-multicast-perl \
+libjson-perl \
+libjson-xs-perl \
+libmail-sendmail-perl \
+libsocket-perl \
+libswitch-perl \
+libsys-hostname-long-perl \
+libterm-readkey-perl \
+libterm-readline-perl-perl \
+libxml-simple-perl \
+libcrypt-pbkdf2-perl \
+libcpan-meta-yaml-perl \
+libxml-simple-perl \
+build-essential
+
+RUN cpan install Net::MQTT:Simple
 
 # Install Fhem
 RUN echo Europe/Berlin > /etc/timezone && dpkg-reconfigure tzdata
 
-# Option 1: Install Fhem via dpkg
-# Dependencies for Fhem
-#RUN apt-get -y install libdevice-serialport-perl \
-#libcgi-pm-perl \
-#sqlite3 \
-#libdbd-sqlite3-perl \
-#libdbd-sqlite3-perl \
-#libtext-diff-perl
-#ENV FHEM_VERSION 5.8
-#RUN wget https://fhem.de/fhem-${FHEM_VERSION}.deb && dpkg -i fhem-${FHEM_VERSION}.deb
-#RUN userdel fhem
-
-# Option 2: Install Fhem via apt-get
+# Install Fhem via apt-get
 RUN touch /sbin/init
 RUN apt-get -y install gnupg
 RUN wget -qO - https://debian.fhem.de/archive.key | apt-key add -

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,46 +4,68 @@ MAINTAINER michaelatdocker <michael.kunzmann@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update
-RUN apt-get -y --force-yes install wget apt-transport-https
+# Install Base Packages
+RUN apt-get update && apt-get -y install apt-utils wget apt-transport-https supervisor telnet
+
+# Setup Supervisor
+RUN mkdir -p /var/log/supervisor
+COPY ./etc/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Install perl packages
-RUN apt-get -y --force-yes install libalgorithm-merge-perl \
-libclass-isa-perl \
-libcommon-sense-perl \
-libdpkg-perl \
-liberror-perl \
-libfile-copy-recursive-perl \
-libfile-fcntllock-perl \
-libio-socket-ip-perl \
-libio-socket-multicast-perl \
-libjson-perl \
-libjson-xs-perl \
-libmail-sendmail-perl \
-libsocket-perl \
-libswitch-perl \
-libsys-hostname-long-perl \
-libterm-readkey-perl \
-libterm-readline-perl-perl \
-libxml-simple-perl \
-libcrypt-pbkdf2-perl \
-libcpan-meta-yaml-perl \
-libxml-simple-perl \
-build-essential
+#RUN apt-get -y install libalgorithm-merge-perl \
+#libclass-isa-perl \
+#libcommon-sense-perl \
+#libdpkg-perl \
+#liberror-perl \
+#libfile-copy-recursive-perl \
+#libfile-fcntllock-perl \
+#libio-socket-ip-perl \
+#libio-socket-multicast-perl \
+#libjson-perl \
+#libjson-xs-perl \
+#libmail-sendmail-perl \
+#libsocket-perl \
+#libswitch-perl \
+#libsys-hostname-long-perl \
+#libterm-readkey-perl \
+#libterm-readline-perl-perl \
+#libxml-simple-perl \
+#libcrypt-pbkdf2-perl \
+#libcpan-meta-yaml-perl \
+#libxml-simple-perl \
+#build-essential
+#
+#RUN cpan install Net::MQTT:Simple
 
-RUN cpan install Net::MQTT:Simple
+# Install Fhem
+RUN echo Europe/Berlin > /etc/timezone && dpkg-reconfigure tzdata
 
+# Option 1: Install Fhem via dpkg
+# Dependencies for Fhem
+#RUN apt-get -y install libdevice-serialport-perl \
+#libcgi-pm-perl \
+#sqlite3 \
+#libdbd-sqlite3-perl \
+#libdbd-sqlite3-perl \
+#libtext-diff-perl
+#ENV FHEM_VERSION 5.8
+#RUN wget https://fhem.de/fhem-${FHEM_VERSION}.deb && dpkg -i fhem-${FHEM_VERSION}.deb
+#RUN userdel fhem
+
+# Option 2: Install Fhem via apt-get
+RUN touch /sbin/init
+RUN apt-get -y install gnupg
 RUN wget -qO - https://debian.fhem.de/archive.key | apt-key add -
 RUN echo "deb https://debian.fhem.de/nightly/ /" | tee -a /etc/apt/sources.list.d/fhem.list
 RUN apt-get update
-RUN apt-get -y --force-yes install supervisor fhem telnet
-RUN mkdir -p /var/log/supervisor
+RUN apt-get -y --force-yes install fhem
+RUN userdel fhem
 
-RUN echo Europe/Berlin > /etc/timezone && dpkg-reconfigure tzdata
-
-COPY ./etc/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+# Clean up APT when done.
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 VOLUME ["/opt/fhem"]
 EXPOSE 8083
 
 CMD ["/usr/bin/supervisord"]
+


### PR DESCRIPTION
Hi,

your docker-fhem container has currently two errors while building (compare hub.docker.com).

1. supervisor installation

The supervisor installation at the end of your scripted failed with the following error:

Setting up supervisor (3.3.1-1+deb9u1) ...
invoke-rc.d: could not determine current runlevel
invoke-rc.d: policy-rc.d denied execution of start.
Errors were encountered while processing:

Because I couldn't found the reason I just moved the supervisor installation to the top for debugging purposes. As result it works without an error, why I stopped there ;-)

2. fhem installation

Within the installation process of fhem a user "fhem" should be created. This fails with the following error:

creating user fhem
stat: cannot stat '/sbin/init': No such file or directory
dpkg: error processing package fhem (--configure):

For the moment I just add a "RUN touch /sbin/init" which seems to work. May you could give it a try.

3.Others

More over I added some comments and cleaning procedures. May you want to use anything.

Martin

